### PR TITLE
Limit logrotate raw rsyslog to *.log files

### DIFF
--- a/recipes/logstash.rb
+++ b/recipes/logstash.rb
@@ -184,7 +184,7 @@ node['logstash']['config'].each_pair do |key, config|
 
     # log rotate the raw logfiles as well as the standard output logs from the logstash services
     logrotate_app "#{service_name}-rawlogs" do
-      path "#{node['logstash']['log_collection_dir']}/#{key}*/*/*"
+      path "#{node['logstash']['log_collection_dir']}/#{key}*/*/*.log"
       options   ['missingok', 'compress', 'notifempty', 'copytruncate']
       frequency 'daily'
       rotate 30


### PR DESCRIPTION
This avoids i-c49ef0e4-production-appserver.log.1.gz.1.gz.1.gz.1.gz...